### PR TITLE
Moves activate before open, and renames for ST3

### DIFF
--- a/open in sublime.applescript
+++ b/open in sublime.applescript
@@ -90,9 +90,9 @@ using terms from application "Path Finder"
 		
 		-- open in Sublime
 		on st2(listOfAliases)
-			tell application "Sublime Text 2"
-				open listOfAliases
+			tell application "Sublime Text"
 				activate
+				open listOfAliases
 			end tell
 		end st2
 		


### PR DESCRIPTION
With the other order, if you don't have ST open, it doesn't take focus, but stays in the background.

And I think most users are likely on ST3 now, which, at least for my recent install, has a name "Sublime Text" with no number.